### PR TITLE
fix: allow `!Default` for `#[serde(default = "..")]` fields

### DIFF
--- a/eserde/src/_macro_impl.rs
+++ b/eserde/src/_macro_impl.rs
@@ -65,12 +65,9 @@ pub enum MaybeInvalid<T> {
     Invalid,
 }
 
-impl<T> Default for MaybeInvalid<T>
-where
-    T: Default,
-{
+impl<T> Default for MaybeInvalid<T> {
     fn default() -> Self {
-        MaybeInvalid::Valid(Default::default())
+        MaybeInvalid::Valid(PhantomData)
     }
 }
 

--- a/eserde/tests/compile_fail/default_unimplemented.rs
+++ b/eserde/tests/compile_fail/default_unimplemented.rs
@@ -1,0 +1,10 @@
+#[derive(eserde::Deserialize)]
+struct Foo {
+    #[serde(default)]
+    field: NoDefault,
+}
+
+#[derive(eserde::Deserialize)]
+struct NoDefault;
+
+fn main() {}

--- a/eserde/tests/compile_fail/default_unimplemented.stderr
+++ b/eserde/tests/compile_fail/default_unimplemented.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `NoDefault: Default` is not satisfied
+ --> tests/compile_fail/default_unimplemented.rs:3:5
+  |
+3 |     #[serde(default)]
+  |     ^ the trait `Default` is not implemented for `NoDefault`
+  |
+help: consider annotating `NoDefault` with `#[derive(Default)]`
+  |
+8 + #[derive(Default)]
+9 | struct NoDefault;
+  |
+
+error[E0277]: the trait bound `NoDefault: Default` is not satisfied
+ --> tests/compile_fail/default_unimplemented.rs:1:10
+  |
+1 | #[derive(eserde::Deserialize)]
+  |          ^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `NoDefault`
+  |
+  = note: this error originates in the derive macro `::eserde::_serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NoDefault` with `#[derive(Default)]`
+  |
+8 + #[derive(Default)]
+9 | struct NoDefault;
+  |

--- a/eserde/tests/default.rs
+++ b/eserde/tests/default.rs
@@ -5,10 +5,21 @@ struct Foo {
     route_0: String,
     #[serde(default = "default_route")]
     route_1: String,
+    #[serde(default = "NoDefault::new")]
+    no_default: NoDefault,
 }
 
 fn default_route() -> String {
-    "/".to_string()
+    "/".to_owned()
+}
+
+// Has no `#[derive(Default)]`.
+#[derive(eserde::Deserialize, Debug, PartialEq, Eq)]
+struct NoDefault;
+impl NoDefault {
+    fn new() -> Self {
+        NoDefault
+    }
 }
 
 #[test]
@@ -17,6 +28,7 @@ fn test_happy() {
         Foo {
             route_0: "/".to_owned(),
             route_1: "/".to_owned(),
+            no_default: NoDefault,
         },
         eserde::json::from_str(r#"{}"#).unwrap()
     );
@@ -25,20 +37,24 @@ fn test_happy() {
         Foo {
             route_0: "/dev/null".to_owned(),
             route_1: "/".to_owned(),
+            no_default: NoDefault,
         },
-        eserde::json::from_str(r#"{"route": "/dev/null"}"#).unwrap()
+        eserde::json::from_str(r#"{"route": "/dev/null", "no_default": null}"#).unwrap()
     );
 }
 
 #[test]
 fn test_fail() {
-    let x = eserde::json::from_str::<Foo>(r#"{"route": 0, "route_1": true, "route_2": 5.5}"#);
+    let x = eserde::json::from_str::<Foo>(
+        r#"{"route": 0, "route_1": true, "no_default": "5", "route_2": 5.5}"#,
+    );
     assert!(x.is_err(), "Expected Err: {:?}", x);
     let errs = x.unwrap_err();
     insta::assert_snapshot!(errs, @r###"
     Something went wrong during deserialization:
     - route: invalid type: integer `0`, expected a string at line 1 column 11
     - route_1: invalid type: boolean `true`, expected a string at line 1 column 28
-    - route_2: unknown field `route_2`, expected `route` or `route_1` at line 1 column 39
+    - no_default: invalid type: string "5", expected unit struct __ImplEDeserializeForNoDefault at line 1 column 47
+    - route_2: unknown field `route_2`, expected one of `route`, `route_1`, `no_default` at line 1 column 58
     "###);
 }


### PR DESCRIPTION
Didn't properly check this case, this is the fix, with the test expanded to cover this case