### PR TITLE
feat: support `#[serde(with = "..")]` on fields, #18

### DIFF
--- a/eserde/src/lib.rs
+++ b/eserde/src/lib.rs
@@ -445,7 +445,6 @@ pub mod _macro_impl;
 ///
 /// The following [field attributes](https://serde.rs/field-attrs.html) will be rejected at compile-time:
 /// - `#[serde(skip_deserializing)]`
-/// - `#[serde(with = "...")]`
 /// - `#[serde(bound = "...")]`
 ///
 /// We plan to support most of these attributes in the future.

--- a/eserde/tests/deserialize_with.rs
+++ b/eserde/tests/deserialize_with.rs
@@ -6,7 +6,7 @@ struct DeserializeWith {
     #[serde(rename = "number", deserialize_with = "deserialize_u8")]
     num: Result<u8, u64>,
 
-    #[serde(deserialize_with = "parse_generic")]
+    #[serde(with = "serde_fromstr")]
     ip: Result<IpAddr, String>,
 }
 
@@ -18,13 +18,15 @@ where
     Ok(u8::try_from(long).map_err(|_| long))
 }
 
-fn parse_generic<'de, T, D>(deserializer: D) -> Result<Result<T, String>, D::Error>
-where
-    T: std::str::FromStr,
-    D: serde::Deserializer<'de>,
-{
-    let s: String = serde::de::Deserialize::deserialize(deserializer)?;
-    Ok(s.parse().map_err(|_| s))
+mod serde_fromstr {
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Result<T, String>, D::Error>
+    where
+        T: std::str::FromStr,
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::de::Deserialize::deserialize(deserializer)?;
+        Ok(s.parse().map_err(|_| s))
+    }
 }
 
 #[test]

--- a/eserde/tests/deserialize_with.rs
+++ b/eserde/tests/deserialize_with.rs
@@ -1,12 +1,12 @@
 use std::net::IpAddr;
 
-#[derive(eserde::Deserialize, Debug, PartialEq, Eq)]
+#[derive(eserde::Deserialize, serde::Serialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 struct DeserializeWith {
     #[serde(rename = "number", deserialize_with = "deserialize_u8")]
     num: Result<u8, u64>,
 
-    #[serde(with = "serde_fromstr")]
+    #[serde(with = "serde_to_from_str")]
     ip: Result<IpAddr, String>,
 }
 
@@ -18,7 +18,7 @@ where
     Ok(u8::try_from(long).map_err(|_| long))
 }
 
-mod serde_fromstr {
+mod serde_to_from_str {
     pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Result<T, String>, D::Error>
     where
         T: std::str::FromStr,
@@ -26,6 +26,17 @@ mod serde_fromstr {
     {
         let s: String = serde::de::Deserialize::deserialize(deserializer)?;
         Ok(s.parse().map_err(|_| s))
+    }
+
+    pub fn serialize<T, S>(value: &Result<T, String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: std::string::ToString,
+        S: serde::Serializer,
+    {
+        match value {
+            Ok(v) => serializer.serialize_str(&v.to_string()),
+            Err(e) => serializer.serialize_str(e),
+        }
     }
 }
 

--- a/eserde_derive/src/model.rs
+++ b/eserde_derive/src/model.rs
@@ -122,21 +122,52 @@ impl PermissiveCompanionType {
                 if is_eserde_compatible {
                     // Add or replace `#[serde(deserialize_with = "..")]` for our wrapper.
 
-                    // Handle user `#[serde(deserialize_with)]` attributes.
+                    // Handle user `#[serde(deserialize_with = "..")]` or `#[serde(with = "..')]` attributes.
                     let dewith_path =
+                        // Remove `#[serde(deserialize_with = "..")]` and get the string value.
                         remove_attr_meta(&mut field.attrs, "serde", "deserialize_with")
                             .and_then(|meta_item| meta_item.value)
                             .and_then(|(_eq, expr)| {
                                 // Get `expr` as a string literal and parse as a path.
-                                let syn::Expr::Lit(syn::ExprLit {
+                                if let syn::Expr::Lit(syn::ExprLit {
                                     attrs: _,
                                     lit: syn::Lit::Str(lit_str),
                                 }) = expr
-                                else {
-                                    return None;
-                                };
-                                syn::parse_str::<syn::Path>(lit_str.value().as_str()).ok()
-                            });
+                                {
+                                    Some(lit_str.value())
+                                } else {
+                                    None
+                                }
+                            })
+                            // Or else remove `#[serde(with = "..")]` and get the string value.
+                            .or_else(|| remove_attr_meta(&mut field.attrs, "serde", "with")
+                                .and_then(|meta_item| meta_item.value)
+                                .and_then(|(_eq, expr)| {
+                                    // Get `expr` as the string literal value.
+                                    if let syn::Expr::Lit(syn::ExprLit {
+                                        attrs: _,
+                                        lit: syn::Lit::Str(lit_str),
+                                    }) = expr
+                                    {
+                                        let path_str = lit_str.value();
+
+                                        // Desugar the serialize side into `#[serde(serialize_with = "$path_str::serialize")]`.
+                                        let path_ser = syn::LitStr::new(
+                                            &format!("{}::serialize", path_str),
+                                            span,
+                                        );
+                                        field.attrs.push(syn::parse_quote_spanned!(span=>
+                                            #[serde(serialize_with = #path_ser)]
+                                        ));
+
+                                        Some(format!("{}::deserialize", path_str))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            )
+                            // Parse the string as a path.
+                            .and_then(|s| syn::parse_str::<syn::Path>(&s).ok());
 
                     let attr = if let Some(dewith_path) = dewith_path {
                         // User specified a custom `deserialize_with` function.

--- a/eserde_derive/src/unsupported.rs
+++ b/eserde_derive/src/unsupported.rs
@@ -85,7 +85,6 @@ fn reject_container_attributes(errors: &mut Vec<syn::Error>, attrs: &[syn::Attri
 fn reject_field_attributes(errors: &mut Vec<syn::Error>, field: &syn::Field) {
     for (path, example) in [
         ("skip_deserializing", "`#[serde(skip_deserializing)]`"),
-        ("with", "`#[serde(with = \"..\")]`"),
         ("bound", "`#[serde(bound = \"..\")]`"),
     ] {
         if let Some(meta_item) = find_attr_meta(&field.attrs, "serde", path) {


### PR DESCRIPTION
Applies to #18, haven't tested `serde_with` crate directly though