### PR TITLE
Expose needed parts for custom deserializers

### DIFF
--- a/eserde/src/errors.rs
+++ b/eserde/src/errors.rs
@@ -66,6 +66,11 @@ pub struct DeserializationError {
 }
 
 impl DeserializationError {
+    /// Creates a new error.
+    pub fn new(path: Option<Path>, details: String) -> Self {
+        Self { path, details }
+    }
+
     /// An explanation of what went wrong during deserialization.
     pub fn message(&self) -> &str {
         self.details.as_ref()

--- a/eserde/src/path/de.rs
+++ b/eserde/src/path/de.rs
@@ -10,6 +10,7 @@ pub struct Deserializer<D> {
 }
 
 impl<D> Deserializer<D> {
+    /// Wraps a deserializer, adding paths to deserializing errors.
     pub fn new(de: D) -> Self {
         Deserializer { de }
     }

--- a/eserde/src/path/mod.rs
+++ b/eserde/src/path/mod.rs
@@ -12,7 +12,6 @@ mod path_;
 mod tracker;
 mod wrap;
 
-#[allow(unused)]
-pub(crate) use de::Deserializer;
+pub use de::Deserializer;
 pub use path_::{Path, Segment, Segments};
 pub(crate) use tracker::PathTracker;


### PR DESCRIPTION
eserde currently does not expose enough to use with deserializers not bundled with it, even though the docs suggest that it should be possible to do so. This pactch rectifies the issue.

* Expose `eserde::path::Deserializer`, which is needed to provide paths to errors.
* Add `eserde::DeserializationError::new`, to be able to construct it, ex from a custom error.
* Tweak the custom deserializer examples in `lib.rs` so that they work, and remove `ignore`.

Fixes #48, #49