### PR TITLE
Upgrade toml to TOML 1.1 (toml 0.9.10 crate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/target*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "toml",
+ "toml 0.9.10+spec-1.1.0",
  "trybuild",
 ]
 
@@ -397,9 +397,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "http"
@@ -490,9 +490,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -741,18 +741,28 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -794,11 +804,20 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -901,37 +920,83 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
+name = "toml"
+version = "0.9.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.24"
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -1005,7 +1070,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1131,9 +1196,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ syn = "2"
 tracing = "0.1"
 trybuild = "1"
 uuid = "1"
-toml = "0.8"
+toml = {version="0.9", features = ["parse", "serde"]}

--- a/eserde/src/path/path_.rs
+++ b/eserde/src/path/path_.rs
@@ -51,7 +51,7 @@ impl Path {
     }
 
     /// Returns an iterator with element type [`&Segment`][Segment].
-    pub fn iter(&self) -> Segments {
+    pub fn iter(&self) -> Segments<'_> {
         Segments {
             iter: self.segments.iter(),
         }

--- a/eserde/src/toml.rs
+++ b/eserde/src/toml.rs
@@ -30,20 +30,23 @@ pub fn from_str<T>(s: &str) -> Result<T, DeserializationErrors>
 where
     T: for<'a> EDeserialize<'a>,
 {
-    let de = toml::Deserializer::new(s);
-    let error = match T::deserialize(de) {
-        Ok(v) => {
-            return Ok(v);
-        }
+    let de = toml::Deserializer::parse(s);
+    let error = match de {
+        Ok(v) => match T::deserialize(v) {
+            Ok(v) => return Ok(v),
+            Err(e) => e,
+        },
         Err(e) => e,
     };
     let _guard = ErrorReporter::start_deserialization();
 
-    let de = toml::Deserializer::new(s);
-    let de = path::Deserializer::new(de);
+    let de = toml::Deserializer::parse(s).and_then(|de| Ok(path::Deserializer::new(de)));
 
-    let errors = match T::deserialize_for_errors(de) {
-        Ok(_) => vec![],
+    let errors = match de {
+        Ok(v) => match T::deserialize_for_errors(v) {
+            Ok(_) => vec![],
+            Err(_) => ErrorReporter::take_errors(),
+        },
         Err(_) => ErrorReporter::take_errors(),
     };
     let errors = if errors.is_empty() {

--- a/eserde/tests/compile_fail/malformed_serde_deserialize_with.stderr
+++ b/eserde/tests/compile_fail/malformed_serde_deserialize_with.stderr
@@ -10,63 +10,63 @@ error: expected serde deserialize_with attribute to be a string: `deserialize_wi
 7 |     #[serde(alias = "1", deserialize_with = false)]
   |                                             ^^^^^
 
-error[E0277]: the trait bound `TryFromIntError: Deserialize<'_>` is not satisfied
+error[E0277]: the trait bound `TryFromIntError: serde::Deserialize<'de>` is not satisfied
  --> tests/compile_fail/malformed_serde_deserialize_with.rs:5:5
   |
-5 |     #[serde(alias = "0", deserialize_with = u64_to_u8())]
-  |     ^ the trait `Deserialize<'_>` is not implemented for `TryFromIntError`
-  |
-  = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `TryFromIntError` type
-  = note: for types from other crates check whether the crate offers a `serde` feature flag
-  = help: the following other types implement trait `Deserialize<'de>`:
-            &'a [u8]
-            &'a std::path::Path
-            &'a str
-            ()
-            (T,)
-            (T0, T1)
-            (T0, T1, T2)
-            (T0, T1, T2, T3)
-          and $N others
-  = note: required for `Result<u8, TryFromIntError>` to implement `Deserialize<'_>`
-  = note: required for `Result<u8, TryFromIntError>` to implement `EDeserialize<'_>`
+ 5 |     #[serde(alias = "0", deserialize_with = u64_to_u8())]
+   |     ^ the trait `Deserialize<'_>` is not implemented for `TryFromIntError`
+   |
+   = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `TryFromIntError` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a [u8]
+             &'a std::path::Path
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+           and $N others
+   = note: required for `Result<u8, TryFromIntError>` to implement `Deserialize<'_>`
+   = note: required for `Result<u8, TryFromIntError>` to implement `EDeserialize<'_>`
 note: required by a bound in `maybe_invalid_or_missing`
- --> src/_macro_impl.rs
-  |
-  | pub fn maybe_invalid_or_missing<'de, D, T>(
-  |        ------------------------ required by a bound in this function
+  --> src/_macro_impl.rs
+   |
+   | pub fn maybe_invalid_or_missing<'de, D, T>(
+   |        ------------------------ required by a bound in this function
 ...
-  |     T: EDeserialize<'de>,
-  |        ^^^^^^^^^^^^^^^^^ required by this bound in `maybe_invalid_or_missing`
+   |     T: EDeserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^^ required by this bound in `maybe_invalid_or_missing`
 
-error[E0277]: the trait bound `TryFromIntError: Deserialize<'_>` is not satisfied
+error[E0277]: the trait bound `TryFromIntError: serde::Deserialize<'de>` is not satisfied
  --> tests/compile_fail/malformed_serde_deserialize_with.rs:7:5
   |
-7 |     #[serde(alias = "1", deserialize_with = false)]
-  |     ^ the trait `Deserialize<'_>` is not implemented for `TryFromIntError`
-  |
-  = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `TryFromIntError` type
-  = note: for types from other crates check whether the crate offers a `serde` feature flag
-  = help: the following other types implement trait `Deserialize<'de>`:
-            &'a [u8]
-            &'a std::path::Path
-            &'a str
-            ()
-            (T,)
-            (T0, T1)
-            (T0, T1, T2)
-            (T0, T1, T2, T3)
-          and $N others
-  = note: required for `Result<u8, TryFromIntError>` to implement `Deserialize<'_>`
-  = note: required for `Result<u8, TryFromIntError>` to implement `EDeserialize<'_>`
+ 7 |     #[serde(alias = "1", deserialize_with = false)]
+   |     ^ the trait `Deserialize<'_>` is not implemented for `TryFromIntError`
+   |
+   = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `TryFromIntError` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a [u8]
+             &'a std::path::Path
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+           and $N others
+   = note: required for `Result<u8, TryFromIntError>` to implement `Deserialize<'_>`
+   = note: required for `Result<u8, TryFromIntError>` to implement `EDeserialize<'_>`
 note: required by a bound in `maybe_invalid_or_missing`
- --> src/_macro_impl.rs
-  |
-  | pub fn maybe_invalid_or_missing<'de, D, T>(
-  |        ------------------------ required by a bound in this function
+  --> src/_macro_impl.rs
+   |
+   | pub fn maybe_invalid_or_missing<'de, D, T>(
+   |        ------------------------ required by a bound in this function
 ...
-  |     T: EDeserialize<'de>,
-  |        ^^^^^^^^^^^^^^^^^ required by this bound in `maybe_invalid_or_missing`
+   |     T: EDeserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^^ required by this bound in `maybe_invalid_or_missing`
 
 error[E0599]: no function or associated item named `deserialize` found for struct `__ImplDeserializeForCoord` in the current scope
  --> tests/compile_fail/malformed_serde_deserialize_with.rs:3:10

--- a/eserde/tests/compile_fail/meta_item_attribute_syntax_bad.stderr
+++ b/eserde/tests/compile_fail/meta_item_attribute_syntax_bad.stderr
@@ -10,7 +10,7 @@ error: duplicate serde attribute `default`
 3 |     #[serde(default - this parses but is not Meta Item Attribute Syntax, serde errors "expected `,`")]
   |     ^
 
-error[E0277]: the trait bound `__ImplEDeserializeForFoo: Deserialize<'_>` is not satisfied
+error[E0277]: the trait bound `__ImplEDeserializeForFoo: serde::Deserialize<'de>` is not satisfied
  --> tests/compile_fail/meta_item_attribute_syntax_bad.rs:2:8
   |
 2 | struct Foo {

--- a/eserde/tests/toml.rs
+++ b/eserde/tests/toml.rs
@@ -66,12 +66,12 @@ fn test_parse_failure() {
     );
     assert!(x.is_err(), "Expected Err: {:?}", x);
     let errs = x.unwrap_err();
-    insta::assert_snapshot!(errs, @r#"
+    insta::assert_snapshot!(errs, @r"
     Something went wrong during deserialization:
     - TOML parse error at line 2, column 20
       |
     2 |     parse_fail_here
       |                    ^
-    expected `.`, `=`
-    "#);
+    key with no value, expected `=`
+    ");
 }

--- a/eserde_derive/src/emit.rs
+++ b/eserde_derive/src/emit.rs
@@ -88,7 +88,7 @@ impl<'a> ImplDeserGenerics<'a> {
         &self,
     ) -> (
         syn::ImplGenerics<'_>,
-        syn::TypeGenerics,
+        syn::TypeGenerics<'_>,
         Option<&syn::WhereClause>,
     ) {
         let (impl_generics, _, where_clause) = self.deser_generics.split_for_impl();


### PR DESCRIPTION
The TOML 1.1.0 spec just dropped, allowing inline tables at last.

The rust-toml crate has already been updated, this updates it here
and fixes the type drift. 

Test cases were adjusted for the minor output changes with the new version.